### PR TITLE
Change references to github.com/majek/slirpnetstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export GOPRIVATE := code.cfops.it
-IMPORT_PATH := github.com/majek/slirpnetstack
+IMPORT_PATH := github.com/cloudflare/slirpnetstack
 
 VERSION := $(shell git describe --tags --always --dirty="-dev")
 DATE    := $(shell date -u '+%Y-%m-%d-%H:%MUTC')

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Perhaps a more powerful way is to see slirpnetstack in action with
 gvisor. To avoid docker magic we can use OCI gvisor interface. See the
 script:
 
-   - https://github.com/majek/slirpnetstack/blob/master/test-gvisor.sh
+   - https://github.com/cloudflare/slirpnetstack/blob/master/test-gvisor.sh
 
 Once you run it, you will see:
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/majek/slirpnetstack
+module github.com/cloudflare/slirpnetstack
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/system"
 	"golang.org/x/sys/unix"
 
-	"github.com/majek/slirpnetstack/ext"
+	"github.com/cloudflare/slirpnetstack/ext"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/tcpip/link/sniffer"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"

--- a/tests/mockudpecho/mockudpecho.go
+++ b/tests/mockudpecho/mockudpecho.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/majek/slirpnetstack/unconn"
+	"github.com/cloudflare/slirpnetstack/unconn"
 )
 
 func main() {


### PR DESCRIPTION
This change modifies instances of the url github.com/majek/slirpnetstack to be github.com/cloudflare/slirpnetstack, as the former redirects to the latter.  Some external references configured to use the old repo path (e.g. travis) are left alone.